### PR TITLE
FMT_SMF dependencies for communications

### DIFF
--- a/Modules/Server/cPP_MOD-Server.adoc
+++ b/Modules/Server/cPP_MOD-Server.adoc
@@ -206,7 +206,7 @@ The TSF shall be capable of performing the following management functions:
 
 * [_selection:_ 
 
-** _configuration of communication with Agent_
+** _configuration of communication with Agent according to FCO_CPC_EXT.1/Server and FPT_ITT.1/Server_
 ** _allow/disallow the enrollment of a TOE agent by administative function or policy,_
 ** _query agent version,_
 ** _provide update functionality to agent,_
@@ -220,7 +220,6 @@ The TSF shall be capable of performing the following management functions:
 
 Application Note {counter:appnote}: Functions that relate to management of agents is intended to be used in conjuction with the Agent module, however, it can be used with third party agents that aren't necessarily within the TOE boundary.
 
-If "communication with Agent" is selected then the FCO_CPC_EXT.1/Server and FPT_ITT.1/Server SFRs will be selected. 
 
 
 === Protection of the TSF (FPT)

--- a/Modules/Server/cPP_MOD-Server.adoc
+++ b/Modules/Server/cPP_MOD-Server.adoc
@@ -206,7 +206,7 @@ The TSF shall be capable of performing the following management functions:
 
 * [_selection:_ 
 
-** _configuration of communication with Agent according to FCO_CPC_EXT.1/Server and FPT_ITT.1/Server_
+** _configuration of communication with Agent according to FCO_CPC_EXT.1/Server, FIA_X509_EXT.1/ITT/Certificate Validation/Server and FPT_ITT.1/Server_
 ** _allow/disallow the enrollment of a TOE agent by administative function or policy,_
 ** _query agent version,_
 ** _provide update functionality to agent,_
@@ -281,9 +281,7 @@ _]._
 ** Client certificates presented for TLS shall have the Client Authentication purpose (id-kp 2 with OID 1.3.6.1.5.5.7.3.2) in the extendedKeyUsage field.
 ** OCSP certificates presented for OCSP responses shall have the OCSP Signing purpose (id-kp 9 with OID 1.3.6.1.5.5.7.3.9) in the extendedKeyUsage field.
 
-Application Note {counter:appnote}: This SFR should be chosen if in FPT_ITT.1/Server protocols selected utilize X.509 certificates for peer authentication. In this case, the use of revocation list checking is optional as there are additional requirements surrounding the enabling and disabling of the ITT channel as defined in FCO_CPC_EXT.1/Server. If revocation checking is not supported, the ST author should select no revocation method. However, if certificate revocation checking is supported, the ST author selects whether this is performed using OCSP or CRLs.
-
-It is acceptable for the TOE to depend on the platform for certification checking (as defined in this SFR) however all the evaluation activities must be performed irrespective of whether the TOE performs the certificate checking or passes the responsibility to the platform.
+Application Note {counter:appnote}: It is acceptable for the TOE to depend on the platform for certification checking (as defined in this SFR) however all the evaluation activities must be performed irrespective of whether the TOE performs the certificate checking or passes the responsibility to the platform.
 
 The TSF shall be capable of supporting a minimum path length of two certificates. That is, it shall support a certificate hierarchy comprising of at least a self-signed root certificate and a TOE identity certificate. 
 


### PR DESCRIPTION
This makes the SFRs in the communications explicitly required to meet the selection instead of having that in the Application Note.