### PR TITLE
objectives edit

### DIFF
--- a/cPP/cPP_APP_SW.adoc
+++ b/cPP/cPP_APP_SW.adoc
@@ -40,7 +40,7 @@ toc::[]
 == Preface
 
 === Objectives of Document
-This document presents the Common Criteria (CC) collaborative Protection Profile (cPP) to express the security functional requirements (SFRs) and security assurance requirements (SARs) for _some technology type_. The Evaluation activities that specify the actions the evaluator performs to determine if a product satisfies the SFRs captured within this cPP, are described in <<SD>>.
+This document presents the Common Criteria (CC) collaborative Protection Profile (cPP) to express the security functional requirements (SFRs) and security assurance requirements (SARs) for application software. The Evaluation activities that specify the actions the evaluator performs to determine if a product satisfies the SFRs captured within this cPP, are described in <<SD>>.
 
 === Scope of Document
 The scope of the cPP within the development and evaluation process is described in the Common Criteria for Information Technology Security Evaluation. In particular, a cPP defines the IT security requirements of a generic type of TOE and specifies the functional security measures to be offered by that TOE to meet stated requirements [<<CC1>>, Section B.14].


### PR DESCRIPTION
Found "some technology type" left over from the template. I don't know if "application software" is sufficient or if there is a desire to say something like "enterprise application software".