### PR TITLE
imagesdir

### DIFF
--- a/cPP/cPP_APP_SW.adoc
+++ b/cPP/cPP_APP_SW.adoc
@@ -4,7 +4,7 @@
 :toclevels: 7
 :sectnums:
 :sectnumlevels: 7
-:imagesdir:
+:imagesdir: images
 :icons: font
 :revnumber: 1.0 
 :revdate: 2022-02-23


### PR DESCRIPTION
setting the imagesdir folder

This should be set so when the DITAA images are generated they are placed into that folder.